### PR TITLE
Update path.py - MacOS - 10.14 -wolframe engine - 12_0

### DIFF
--- a/wolframclient/evaluation/kernel/path.py
+++ b/wolframclient/evaluation/kernel/path.py
@@ -44,6 +44,7 @@ def installation_directories():
     elif six.MACOS:
         yield '/Applications/Wolfram Desktop.app/Contents'
         yield '/Applications/Mathematica.app/Contents'
+        yield '/Applications/Wolfram Engine.app/Contents'
 
 
 def exe_path():


### PR DESCRIPTION
Was not working on my notebook - using the free version of wolframe engine - path invalid
while starting the session . 