### PR TITLE
Add link to contributors guide in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,4 +41,4 @@ This project is released under the MIT licence.
 Contributions
 =============
 
-The library is maintained by Wolfram Research. The code is on Github. Pull requests and suggestions are always welcomed.
+The library is maintained by Wolfram Research. The code is on Github. Pull requests and suggestions are always welcomed. See `our contributor's guide <https://github.com/WolframResearch/WolframClientForPython/blob/master/CONTRIBUTING.md>`_ for more info.


### PR DESCRIPTION
It help new Github users to find it easily.