### PR TITLE
clarified conversion of classes with iter method

### DIFF
--- a/docs/docpages/public_api.rst
+++ b/docs/docpages/public_api.rst
@@ -79,7 +79,7 @@ Example::
     >>> export({"list": [1, 2, 3], "set": set([1, 2, 2, 4]), "frozenset": frozenset([1, 2, 2, 4]), "dict": dict(a = 2)})
     '<|"list" -> {1, 2, 3}, "set" -> {1, 2, 4}, "frozenset" -> {1, 2, 4}, "dict" -> <|"a" -> 2|>|>'
 
-Any class that has an `__iter__` method is converted to a Wolfram Language :wl:`List`::
+If no converter is defined for a class that has an `__iter__` method, it is converted to a Wolfram Language :wl:`List`::
 
     >>> export((i + 2 for i in range(10)))
     '"{2, 3, 4, 5, 6, 7, 8, 9, 10, 11}"'


### PR DESCRIPTION
Previously doc pages said _"Any class that has an __iter__ method is converted to a Wolfram Language List"_ implying that dict is serialized as a List. It is not. 

I've clarified the statement with a suggestion that reads: _"If no converter is defined for a class that has an __iter__ method, it is converted to a WL List"_