### PR TITLE
Fix bug in utils.py occuring since python version 3.12.3

### DIFF
--- a/wolframclient/serializers/utils.py
+++ b/wolframclient/serializers/utils.py
@@ -9,7 +9,7 @@ from wolframclient.utils.encoding import force_bytes
 
 ESCAPE = re.compile(r'[\x00\\"\b\f\n\r\t]')
 ESCAPE_DCT = {
-    chr(0): "\.00",
+    chr(0): "\\.00",
     "\\": "\\\\",
     '"': '\\"',
     "\b": "\\b",


### PR DESCRIPTION
In python version [3.12.3 PEP 701](https://peps.python.org/pep-0701/) they changed how f strings get parsed. As a result "\\.00" gives an error now instead of \\\\.00.
I tested that the bug fix also works with python version 3.11.9.