### PR TITLE
Encode the pandas NaT (not-a-time) singleton type (fixes #43)

### DIFF
--- a/wolframclient/serializers/encoders/pandas.py
+++ b/wolframclient/serializers/encoders/pandas.py
@@ -183,3 +183,8 @@ def encoder_panda_dataframe(serializer, o):
                 ", ".join(PANDAS_PROPERTIES["pandas_dataframe_head"]), head
             )
         )
+
+
+@encoder.dispatch(pandas.NaT)
+def encode_pandas_not_a_time(serializer, o):
+    return serializer.serialize_symbol(b"Indeterminate")

--- a/wolframclient/utils/api.py
+++ b/wolframclient/utils/api.py
@@ -168,6 +168,7 @@ pandas = API(
     SparseSeries="pandas.SparseSeries",
     SparseArray="pandas.SparseArray",
     bdate_range="pandas.bdate_range",
+    NaT="pandas.api.typing.NaTType",
 )
 
 aiohttp = API(


### PR DESCRIPTION
The pandas package has a singleton pandas.NaT of type pandas.api.typing.NaTType to represent an entry in a datetime field which is missing/broken/null. A reasonable encoding is pandas.NaT -> Indeterminate