### PR TITLE
Bump Version in PacletInfo.m to match version in about.py

### DIFF
--- a/PacletInfo.m
+++ b/PacletInfo.m
@@ -1,6 +1,6 @@
 Paclet[
     Name -> "WolframClientForPython",
-    Version -> "1.4.0",
+    Version -> "1.4.1",
     MathematicaVersion -> "14.1+",
     Loading -> Automatic,
     Extensions -> {}


### PR DESCRIPTION
So that `PacletBuild[]` knows there is an updated version number.

Would love for the latest version to also be deployed to PyPI (and a conda-forge recipe so that `conda install` would also work)